### PR TITLE
Add circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2
+jobs:
+  py27: &py27
+    docker:
+    - image: python:2.7
+    steps:
+    - checkout
+    - run: tox -e py27
+  py3:
+    docker:
+    - image: python:3
+    steps:
+    - checkout
+    - run: tox -e py3
+workflows:
+  build:
+    jobs:
+    - py27
+    - py3

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CircleCI](https://circleci.com/gh/mozilla/addons_daily.svg?style=svg)](https://circleci.com/gh/mozilla/addons_daily)
+
 # `addons_daily` Derived Dataset
 Contributers: Sarah Melancon, Ben Miroglio, Brian Wright
 


### PR DESCRIPTION
someone with admin on this repo needs to go to https://circleci.com/gh/mozilla/addons_daily/edit and choose `follow project` to enable circleci builds