### PR TITLE
Fix #64 - Materialize range generator into a list 

### DIFF
--- a/addons_daily/addons_report.py
+++ b/addons_daily/addons_report.py
@@ -120,6 +120,7 @@ def main(
     base_date = "to_date('{}')".format(fdate(date))
     # leave main_summary fitlered to last 28 days
     # to get trend metrics
+    sample_ids = list(range(0, sample))
     main_summary = (
         load_data_s3(
             spark,
@@ -127,7 +128,7 @@ def main(
             input_prefix="main_summary",
             input_version=main_summary_version,
         )
-        .filter(F.col("sample_id").isin(range(0, sample)))
+        .filter(F.col("sample_id").isin(sample_ids))
         .filter("submission_date_s3 >= ({} - INTERVAL 28 DAYS)".format(base_date))
         .filter("normalized_channel = 'release'")
     )
@@ -139,7 +140,7 @@ def main(
             input_prefix="search_clients_daily",
             input_version=search_clients_daily_version,
         )
-        .filter(F.col("sample_id").isin(range(0, sample)))
+        .filter(F.col("sample_id").isin(sample_ids))
         .filter("submission_date_s3 = '{}'".format(date))
         .filter("channel = 'release'")
     )
@@ -151,7 +152,7 @@ def main(
             input_prefix="events",
             input_version=events_version,
         )
-        .filter(F.col("sample_id").isin(range(0, sample)))
+        .filter(F.col("sample_id").isin(sample_ids))
         .filter("submission_date_s3 = '{}'".format(date))
         .filter("normalized_channel = 'release'")
     )

--- a/addons_daily/addons_report.py
+++ b/addons_daily/addons_report.py
@@ -121,6 +121,11 @@ def main(
     search_clients_daily_version,
     events_version,
 ):
+    if not any(output.startswith(prefix) for prefix in ["file://", "s3://"]):
+        raise ValueError(
+            "Unsupported data source, "
+            "`--output` must start with either `file://` or `s3://`."
+        )
     if not output.endswith("/"):
         output = output + "/"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+from pyspark.sql import SparkSession
+
+
+@pytest.fixture(scope="session")
+def spark():
+    spark = SparkSession.builder.appName("addons_daily_tests").getOrCreate()
+    spark.conf.set("spark.sql.session.timeZone", "UTC")
+    yield spark
+    spark.stop()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -38,12 +38,6 @@ def df_to_json(df):
 
 
 @pytest.fixture()
-def spark():
-    spark_session = SparkSession.builder.appName("addons_daily_tests").getOrCreate()
-    return spark_session
-
-
-@pytest.fixture()
 def main_summary(spark):
     return load_df_from_json("main_summary", spark)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -116,10 +116,9 @@ def test_main(
     monkeypatch.setattr(
         addons_daily.addons_report, "load_raw_pings", mock_load_raw_pings
     )
-    monkeypatch.setattr(addons_daily.addons_report, "OUTPATH", str(tmpdir) + "/")
 
     runner = CliRunner()
-    result = runner.invoke(main, ["--date", BASE_DATE])
+    result = runner.invoke(main, ["--date", BASE_DATE, "--output", str(tmpdir)])
     assert result.exit_code == 0
     submission_path = tmpdir / "submission_date_s3={}".format(BASE_DATE)
     assert os.path.exists(submission_path)

--- a/tests/test_raw_pings.py
+++ b/tests/test_raw_pings.py
@@ -16,9 +16,8 @@ def load_expected_data(filename, spark):
 
 
 @pytest.fixture()
-def raw_pings():
-    sc = SparkContext.getOrCreate()
-    spark = SQLContext.getOrCreate(sc)
+def raw_pings(spark):
+    sc = spark.sparkContext
     return load_keyed_hist(sc.parallelize(load_expected_data("raw_pings.json", spark)))
 
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -30,12 +30,6 @@ def load_test_data(prefix, spark):
 
 
 @pytest.fixture()
-def spark():
-    spark_session = SparkSession.builder.appName("addons_daily_tests").getOrCreate()
-    return spark_session
-
-
-@pytest.fixture()
 def main_summary(spark):
     return load_test_data("main_summary", spark)
 


### PR DESCRIPTION
This fixes issue #64 which is currently causing failures in Airflow. I've disabled the DAG until this patch goes through. The failure because Python3 serializes the generator function for `range`, instead of the values of range.

This patch contains the following:
* Reproduces the bug locally using click's `CliRunner` tooling
* Fixes issue #64 by calling `list`
* Adds an option for `--output` that defaults to `OUTPATH` for integration testing via `mozetl-databricks.py`
* Uses a common `spark` fixture in `conftest.py` that lasts the entire testing session

```bash
python bin/mozetl-databricks.py \
    --git-path https://github.com/acmiyaguchi/addons_daily.git \
    --git-branch master \
    --module-name addons_daily \
    --num-workers 10 \
    --python 3 \
    --token <TOKEN>  \
    addons_report \
        --date 20190608 \
	--output s3://telemetry-test-bucket/addons_daily/v1/
```
Cluster logs: https://dbc-caf9527b-e073.cloud.databricks.com/#job/3395/run/1