### PR TITLE
Pin docker image to use debian stretch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   py3:
     docker:
-    - image: python:3
+    - image: python:3-stretch
     steps:
     - checkout
     - run:


### PR DESCRIPTION
This should fix issues with the CircleCI build/test.